### PR TITLE
application cannot cast to MainApplication

### DIFF
--- a/17_dagger/README.md
+++ b/17_dagger/README.md
@@ -99,7 +99,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (application as MainApplication).appComponent.inject(this)
+        MainApplication().appComponent.inject(this)
 
         setContentView(R.layout.activity_main)
 


### PR DESCRIPTION
@yanzm Dagger回に参加させて貰った者です。
MainApplicationはandroid.app.Applicationクラスを継承しているはずなので、下記のエラーが出る理屈がいまいちわかりません。（typo等確認したつもりです…）
かといって、下記のコミットのように呼出しをするくらいなら、MainActivityでappComponentを宣言してあげてもいいと思うのですが、これをしてしまうと設計的によろしくないのでしょうか？

Q1. キャストがうまくいかない理由
Q2. MainApplicationを切り分ける理由

ご回答のほどよろしくお願い致します。

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: net.yanzm.daggersample, PID: 4390
    java.lang.RuntimeException: Unable to start activity ComponentInfo{net.yanzm.daggersample/net.yanzm.daggersample.MainActivity}: java.lang.ClassCastException: android.app.Application cannot be cast to net.yanzm.daggersample.MainApplication
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2913)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
        at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:4784)
        at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4693)
        at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:69)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ClientTransactionHandler.executeTransaction(ClientTransactionHandler.java:55)
        at android.app.ActivityThread.handleRelaunchActivityLocally(ActivityThread.java:4743)
        at android.app.ActivityThread.access$3200(ActivityThread.java:199)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1818)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
     Caused by: java.lang.ClassCastException: android.app.Application cannot be cast to net.yanzm.daggersample.MainApplication
        at net.yanzm.daggersample.MainActivity$override.onCreate(MainActivity.kt:20)
        at net.yanzm.daggersample.MainActivity$override.access$dispatch(Unknown Source:112)
        at net.yanzm.daggersample.MainActivity.onCreate(Unknown Source:15)
        at android.app.Activity.performCreate(Activity.java:7136)
        at android.app.Activity.performCreate(Activity.java:7127)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1271)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2893)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048) 
        at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:4784) 
        at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:4693) 
        at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:69) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68) 
        at android.app.ClientTransactionHandler.executeTransaction(ClientTransactionHandler.java:55) 
        at android.app.ActivityThread.handleRelaunchActivityLocally(ActivityThread.java:4743) 
        at android.app.ActivityThread.access$3200(ActivityThread.java:199) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1818) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:193) 
        at android.app.ActivityThread.main(ActivityThread.java:6669) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858) 
```